### PR TITLE
NXP-23172: Inject only tagged features when using --tags=@watch

### DIFF
--- a/nuxeo-web-ui-ftest/package.json
+++ b/nuxeo-web-ui-ftest/package.json
@@ -22,6 +22,7 @@
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.1",
     "eslint-plugin-react": "^3.16.1",
+    "fs-finder": "^1.8.1",
     "mkdirp": "^0.5.1",
     "wdio-cucumber-framework": "^0.3.1",
     "wdio-firefox-profile-service": "0.0.3",

--- a/nuxeo-web-ui-ftest/scripts/specs-processor.js
+++ b/nuxeo-web-ui-ftest/scripts/specs-processor.js
@@ -1,9 +1,18 @@
-module.exports = (argv) => {
-  const args = require('minimist')(argv.slice(2));
-  if (args['specs']) {
-    return args['specs'].split(',');
-  } else {
-    return ['./test/features/*.feature'];
-  }
-};
+ const Finder = require('fs-finder');
+ const fs = require('fs');
 
+module.exports = (argv) => {
+  let features = [];
+  const args = require('minimist')(argv.slice(2));
+  if (args['cucumberOpts']['tags']) {
+    const files = Finder.from('./test/features').findFiles('*.feature');
+    files.forEach((file) => {
+      if (fs.readFileSync(file, 'utf8').includes(args.cucumberOpts.tags)) {
+        features.push(file);
+      }
+    });
+  } else {
+    features = './test/features/*.feature';
+  }
+  return features;
+};

--- a/nuxeo-web-ui-ftest/scripts/specs-processor.js
+++ b/nuxeo-web-ui-ftest/scripts/specs-processor.js
@@ -6,11 +6,7 @@ module.exports = (argv) => {
   const args = require('minimist')(argv.slice(2));
   if (args['cucumberOpts']['tags']) {
     const files = Finder.from('./test/features').findFiles('*.feature');
-    files.forEach((file) => {
-      if (fs.readFileSync(file, 'utf8').includes(args.cucumberOpts.tags)) {
-        features.push(file);
-      }
-    });
+    features = files.filter(file => fs.readFileSync(file, 'utf8').includes(args.cucumberOpts.tags));
   } else {
     features = './test/features/*.feature';
   }

--- a/nuxeo-web-ui-ftest/scripts/specs-processor.js
+++ b/nuxeo-web-ui-ftest/scripts/specs-processor.js
@@ -1,5 +1,5 @@
- const Finder = require('fs-finder');
- const fs = require('fs');
+const Finder = require('fs-finder');
+const fs = require('fs');
 
 module.exports = (argv) => {
   let features = [];


### PR DESCRIPTION
`npm run test:watch` will still only perform a single pass, but windows will only be spawned for features with tagged scenarios.