### PR TITLE
WEBUI-148: fix selenium-standalone version to a node 6 compatible one

### DIFF
--- a/nuxeo-web-ui-ftest/package.json
+++ b/nuxeo-web-ui-ftest/package.json
@@ -26,6 +26,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.22.0",
     "nuxeo": "^3.6.0",
+    "selenium-standalone": "6.20.2",
     "wdio-cucumber-framework": "^0.3.1",
     "wdio-json-reporter": "^0.3.1",
     "wdio-junit-reporter": "^0.4.2",


### PR DESCRIPTION
Newer versions than selenium-standalone@6.20.2 are not supported in node v6.